### PR TITLE
Add rider accounts and approval flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,11 @@ import AdminDashboard from './pages/Admin/Dashboard/AdminDashboard'
 import MenuEditor from './pages/Admin/MenuEditor/MenuEditor'
 import CustomerTable from './pages/Admin/Customers/CustomerTable'
 import DeliveryTable from './pages/Admin/Delivery/DeliveryTable'
+import RiderLogin from './pages/Rider/RiderLogin'
+import RiderSignup from './pages/Rider/RiderSignup'
+import RiderDashboard from './pages/Rider/RiderDashboard'
+import RiderPrivateRoute from './components/RiderPrivateRoute'
+import RiderApproval from './pages/Admin/Riders/RiderApproval'
 
 function App() {
   return (
@@ -32,8 +37,18 @@ function App() {
             <Route path="menu" element={<MenuEditor />} />
             <Route path="customers" element={<CustomerTable />} />
             <Route path="delivery" element={<DeliveryTable />} />
+            <Route path="riders" element={<RiderApproval />} />
           </Route>
-          
+
+          {/* Rider authentication */}
+          <Route path="/rider/login" element={<RiderLogin />} />
+          <Route path="/rider/signup" element={<RiderSignup />} />
+          <Route path="/rider/dashboard" element={
+            <RiderPrivateRoute>
+              <RiderDashboard />
+            </RiderPrivateRoute>
+          } />
+
           {/* Main app routes (with navbar and Glasgow banner) */}
           <Route path="/*" element={
             <>

--- a/src/components/RiderPrivateRoute.tsx
+++ b/src/components/RiderPrivateRoute.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+interface Props {
+  children: React.ReactNode
+}
+
+const RiderPrivateRoute: React.FC<Props> = ({ children }) => {
+  const { currentUser } = useAuth()
+  return currentUser ? <>{children}</> : <Navigate to="/rider/login" />
+}
+
+export default RiderPrivateRoute

--- a/src/pages/Admin/Delivery/DeliveryTable.tsx
+++ b/src/pages/Admin/Delivery/DeliveryTable.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import { 
-  getDeliveryStatuses, 
+import {
+  getDeliveryStatuses,
   updateDeliveryStatus,
-  DeliveryStatus 
+  DeliveryStatus,
+  getApprovedRiders,
+  Rider
 } from '../../../services/firestore'
 import styles from './DeliveryTable.module.css'
 
@@ -18,14 +20,10 @@ const DeliveryTable: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true)
   const [updatingStatus, setUpdatingStatus] = useState<string | null>(null)
 
-  // Delivery partners list
-  const deliveryPartners = [
-    { id: 'unassigned', name: 'Unassigned' },
-    { id: 'ravi', name: 'Ravi Kumar' },
-    { id: 'anjali', name: 'Anjali Sharma' },
-    { id: 'faiz', name: 'Faiz Ahmed' },
-    { id: 'priya', name: 'Priya Patel' }
-  ]
+  // Delivery partners list loaded from Firestore
+  const [deliveryPartners, setDeliveryPartners] = useState<Rider[]>([
+    { id: 'unassigned', name: 'Unassigned', email: '', approved: true }
+  ])
 
   // Status options
   const statusOptions = [
@@ -38,6 +36,7 @@ const DeliveryTable: React.FC = () => {
   // Load delivery statuses from Firestore
   useEffect(() => {
     loadDeliveryStatuses()
+    loadRiders()
   }, [])
 
   const loadDeliveryStatuses = async () => {
@@ -49,6 +48,18 @@ const DeliveryTable: React.FC = () => {
       console.error('Error loading delivery statuses:', error)
     } finally {
       setIsLoading(false)
+    }
+  }
+
+  const loadRiders = async () => {
+    try {
+      const riders = await getApprovedRiders()
+      setDeliveryPartners([
+        { id: 'unassigned', name: 'Unassigned', email: '', approved: true },
+        ...riders
+      ])
+    } catch (error) {
+      console.error('Error loading riders:', error)
     }
   }
 

--- a/src/pages/Admin/Layout/AdminLayout.tsx
+++ b/src/pages/Admin/Layout/AdminLayout.tsx
@@ -39,7 +39,8 @@ const AdminLayout: React.FC = () => {
     { path: '/admin/dashboard', label: 'Dashboard', icon: '📋' },
     { path: '/admin/menu', label: 'Menu Editor', icon: '🍽️' },
     { path: '/admin/customers', label: 'Customers', icon: '👥' },
-    { path: '/admin/delivery', label: 'Delivery & Notifications', icon: '🚚' }
+    { path: '/admin/delivery', label: 'Delivery & Notifications', icon: '🚚' },
+    { path: '/admin/riders', label: 'Riders', icon: '🧑‍✈️' }
   ]
 
   const toggleSidebar = () => {

--- a/src/pages/Admin/Riders/RiderApproval.module.css
+++ b/src/pages/Admin/Riders/RiderApproval.module.css
@@ -1,0 +1,22 @@
+.container {
+  padding: 2rem;
+  font-family: 'Poppins', sans-serif;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+}
+
+.listItem {
+  margin-bottom: 0.5rem;
+}
+
+.button {
+  background: #d62828;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+}

--- a/src/pages/Admin/Riders/RiderApproval.tsx
+++ b/src/pages/Admin/Riders/RiderApproval.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react'
+import { getRiders, updateRider, Rider } from '../../../services/firestore'
+import styles from './RiderApproval.module.css'
+
+const RiderApproval: React.FC = () => {
+  const [riders, setRiders] = useState<Rider[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const load = async () => {
+    setLoading(true)
+    const all = await getRiders()
+    setRiders(all.filter(r => !r.approved))
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const handleApprove = async (id: string) => {
+    await updateRider(id, { approved: true })
+    await load()
+  }
+
+  if (loading) {
+    return <p>Loading riders...</p>
+  }
+
+  return (
+    <div className={styles.container}>
+      <h1>Unapproved Riders</h1>
+      {riders.length === 0 ? (
+        <p>All riders approved.</p>
+      ) : (
+        <ul className={styles.list}>
+          {riders.map(r => (
+            <li key={r.id} className={styles.listItem}>
+              {r.name} ({r.email}){' '}
+              <button
+                onClick={() => handleApprove(r.id!)}
+                className={styles.button}
+              >
+                Approve
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default RiderApproval

--- a/src/pages/Rider/RiderDashboard.module.css
+++ b/src/pages/Rider/RiderDashboard.module.css
@@ -1,0 +1,5 @@
+.dashboard {
+  padding: 2rem;
+  font-family: 'Poppins', sans-serif;
+  color: #2b2b2b;
+}

--- a/src/pages/Rider/RiderDashboard.tsx
+++ b/src/pages/Rider/RiderDashboard.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react'
+import { useAuth } from '../../contexts/AuthContext'
+import { getRiders } from '../../services/firestore'
+import styles from './RiderDashboard.module.css'
+
+const RiderDashboard: React.FC = () => {
+  const { currentUser } = useAuth()
+  const [approved, setApproved] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      if (!currentUser) return
+      const riders = await getRiders()
+      const rider = riders.find(r => r.id === currentUser.uid)
+      setApproved(rider?.approved ?? false)
+    }
+    load()
+  }, [currentUser])
+
+  if (!currentUser) return null
+
+  return (
+    <div className={styles.dashboard}>
+      <h1>Rider Dashboard</h1>
+      {approved === null ? (
+        <p>Loading...</p>
+      ) : approved ? (
+        <p>Welcome {currentUser.email}</p>
+      ) : (
+        <p>Your account is awaiting approval.</p>
+      )}
+    </div>
+  )
+}
+
+export default RiderDashboard

--- a/src/pages/Rider/RiderLogin.module.css
+++ b/src/pages/Rider/RiderLogin.module.css
@@ -1,0 +1,44 @@
+.authContainer {
+  padding: 2rem;
+  font-family: 'Poppins', sans-serif;
+  color: #2b2b2b;
+}
+
+.form {
+  max-width: 400px;
+  margin-top: 1rem;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.input {
+  background: #f5ebe0;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-family: 'Poppins', sans-serif;
+}
+
+.error {
+  color: #d62828;
+  margin-bottom: 1rem;
+}
+
+.button {
+  background: #d62828;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  font-weight: 600;
+}

--- a/src/pages/Rider/RiderLogin.tsx
+++ b/src/pages/Rider/RiderLogin.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { useNavigate, Link } from 'react-router-dom'
+import { useAuth } from '../../contexts/AuthContext'
+import styles from './RiderLogin.module.css'
+
+const RiderLogin: React.FC = () => {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+  const [formData, setFormData] = useState({ email: '', password: '' })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setFormData(prev => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      setLoading(true)
+      await login(formData.email, formData.password)
+      navigate('/rider/dashboard')
+    } catch (err) {
+      console.error('Login error:', err)
+      setError('Invalid credentials')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className={styles.authContainer}>
+      <h1>Rider Login</h1>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <div className={styles.fieldGroup}>
+          <label className={styles.label}>Email</label>
+          <input
+            type="email"
+            name="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+            className={styles.input}
+          />
+        </div>
+        <div className={styles.fieldGroup}>
+          <label className={styles.label}>Password</label>
+          <input
+            type="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+            required
+            className={styles.input}
+          />
+        </div>
+        {error && <p className={styles.error}>{error}</p>}
+        <button type="submit" disabled={loading} className={styles.button}>
+          {loading ? 'Logging in...' : 'Login'}
+        </button>
+      </form>
+      <p>
+        Need an account? <Link to="/rider/signup">Sign Up</Link>
+      </p>
+    </div>
+  )
+}
+
+export default RiderLogin

--- a/src/pages/Rider/RiderSignup.module.css
+++ b/src/pages/Rider/RiderSignup.module.css
@@ -1,0 +1,44 @@
+.authContainer {
+  padding: 2rem;
+  font-family: 'Poppins', sans-serif;
+  color: #2b2b2b;
+}
+
+.form {
+  max-width: 400px;
+  margin-top: 1rem;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.input {
+  background: #f5ebe0;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-family: 'Poppins', sans-serif;
+}
+
+.error {
+  color: #d62828;
+  margin-bottom: 1rem;
+}
+
+.button {
+  background: #d62828;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  font-weight: 600;
+}

--- a/src/pages/Rider/RiderSignup.tsx
+++ b/src/pages/Rider/RiderSignup.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react'
+import { useNavigate, Link } from 'react-router-dom'
+import { createUserWithEmailAndPassword } from 'firebase/auth'
+import { auth } from '../../firebase/config'
+import { createRiderProfile } from '../../services/firestore'
+import styles from './RiderSignup.module.css'
+
+const RiderSignup: React.FC = () => {
+  const navigate = useNavigate()
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    password: ''
+  })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setFormData(prev => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!formData.name || !formData.email || !formData.password) {
+      setError('Please fill in all fields')
+      return
+    }
+    try {
+      setLoading(true)
+      const cred = await createUserWithEmailAndPassword(
+        auth,
+        formData.email,
+        formData.password
+      )
+      await createRiderProfile(cred.user.uid, {
+        email: formData.email,
+        name: formData.name
+      })
+      navigate('/rider/dashboard')
+    } catch (err: any) {
+      console.error('Signup error:', err)
+      setError('Failed to create account')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className={styles.authContainer}>
+      <h1>Rider Signup</h1>
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <div className={styles.fieldGroup}>
+          <label className={styles.label}>Name</label>
+          <input
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            required
+            className={styles.input}
+          />
+        </div>
+        <div className={styles.fieldGroup}>
+          <label className={styles.label}>Email</label>
+          <input
+            type="email"
+            name="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+            className={styles.input}
+          />
+        </div>
+        <div className={styles.fieldGroup}>
+          <label className={styles.label}>Password</label>
+          <input
+            type="password"
+            name="password"
+            value={formData.password}
+            onChange={handleChange}
+            required
+            className={styles.input}
+          />
+        </div>
+        {error && <p className={styles.error}>{error}</p>}
+        <button type="submit" disabled={loading} className={styles.button}>
+          {loading ? 'Signing up...' : 'Sign Up'}
+        </button>
+      </form>
+      <p>
+        Already have an account? <Link to="/rider/login">Login</Link>
+      </p>
+    </div>
+  )
+}
+
+export default RiderSignup

--- a/src/services/firestore.ts
+++ b/src/services/firestore.ts
@@ -1,10 +1,11 @@
 import { 
-  collection, 
-  addDoc, 
-  getDocs, 
-  doc, 
-  updateDoc, 
-  deleteDoc, 
+  collection,
+  addDoc,
+  getDocs,
+  doc,
+  updateDoc,
+  deleteDoc,
+  setDoc,
   query, 
   where, 
   orderBy,
@@ -435,4 +436,52 @@ export const subscribeToMenuItems = (
     } as MenuItem))
     callback(items)
   })
+}
+
+// Rider interface
+export interface Rider {
+  id?: string
+  email: string
+  name: string
+  approved: boolean
+}
+
+// Create rider profile after signup
+export const createRiderProfile = async (
+  uid: string,
+  data: { email: string; name: string }
+) => {
+  await setDoc(doc(db, 'riders', uid), {
+    email: data.email,
+    name: data.name,
+    approved: false
+  })
+}
+
+// Get all riders
+export const getRiders = async (): Promise<Rider[]> => {
+  const snapshot = await getDocs(collection(db, 'riders'))
+  return snapshot.docs.map(docSnap => ({
+    id: docSnap.id,
+    ...docSnap.data()
+  } as Rider))
+}
+
+// Get only approved riders
+export const getApprovedRiders = async (): Promise<Rider[]> => {
+  const q = query(collection(db, 'riders'), where('approved', '==', true))
+  const snapshot = await getDocs(q)
+  return snapshot.docs.map(docSnap => ({
+    id: docSnap.id,
+    ...docSnap.data()
+  } as Rider))
+}
+
+// Update rider document
+export const updateRider = async (
+  id: string,
+  data: Partial<Rider>
+) => {
+  const ref = doc(db, 'riders', id)
+  await updateDoc(ref, data)
 }


### PR DESCRIPTION
## Summary
- add Firestore rider model and CRUD helpers
- implement rider signup/login/dashboard pages
- protect rider pages with RiderPrivateRoute
- list unapproved riders for admins and allow approval
- use rider list in delivery assignment
- wire up rider routes in App and admin navigation
- style new rider pages with CSS modules

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684fe50ad7b08323b1f7dff393bf70c0